### PR TITLE
Fix Homebridge crashes due to uncaught exceptions

### DIFF
--- a/src/LuxorPlatform.ts
+++ b/src/LuxorPlatform.ts
@@ -248,9 +248,7 @@ export class LuxorPlatform implements DynamicPlatformPlugin {
             this.log.error(this.Name + " needs an IP Address in the config file.  Please see sample_config.json.");
         }
         try {
-            let isConnected = false;
-            while (!isConnected){
-                isConnected = await this.getControllerAsync();
+            while (await this.getControllerAsync() == false) {
                 this.log.info(`Unable to connect to Luxor controller.  Waiting 60s and will retry.`)
                 await this.sleep(60*1000);
             }

--- a/src/LuxorPlatform.ts
+++ b/src/LuxorPlatform.ts
@@ -58,9 +58,12 @@ export class LuxorPlatform implements DynamicPlatformPlugin {
         this.log.info(this.Name + ": Starting search for controller at: " + this.config.ipAddr);
         try {
             //Search for controllor and make sure we can find it
-            const response:AxiosResponse = await axios.post(
-                `http://${this.config.ipAddr}/ControllerName.json`
-            )
+            const response = await axios({
+                method: 'post',
+                url: 'http://' + this.config.ipAddr + '/ControllerName.json',
+                timeout: this.config.commandTimeout || 750
+              });
+              
             if (response.status !== 200) { this.log.error('Received a status code of ' + response.status + ' when trying to connect to the controller.'); return false; }
             let controllerNameData = response.data;
             controllerNameData.ip = this.config.ipAddr;

--- a/src/lights/Theme.ts
+++ b/src/lights/Theme.ts
@@ -37,14 +37,12 @@ export class Theme extends ZD_Light {
             await this.illuminateTheme(0);
         })
 
-        try {
-            this.getCurrentStateAsync().then(() => {
-                this.setCharacteristics();
-            });
-        }
-        catch(err){
-            this.log.error(`${this.accessory.displayName} setServices error: ${err}`)
-        }
+        this.getCurrentStateAsync().then(() => {
+            this.setCharacteristics();
+        }).catch((err) => {    
+            this.log.error(`${this.accessory.displayName} setServices error: ${err}`);     
+        });
+        
         // don't register "fake" illumate/extinguish all themes.
         // don't register any themes because we don't care if the controller thinks they are on;
         // we want them to show as 'off' so they can act as a push button

--- a/src/lights/ZDC_Light.ts
+++ b/src/lights/ZDC_Light.ts
@@ -33,21 +33,18 @@ export class ZDC_Light extends ZD_Light {
     }
 
     getHue(callback: CharacteristicGetCallback): void {
-        try {
-            this.controller.GetColorAsync(this.context.color).then(colors => {
-                this.context.hue = colors.Hue;
-                // shouldn't need this
-                // this.service.updateCharacteristic(this.platform.Characteristic.Hue, colors.Hue);
-                // this.service.updateCharacteristic(this.platform.Characteristic.Saturation, colors.Sat);
-                callback(null, this.context.hue);
-            })
-        }
-        catch (err) {
+        this.controller.GetColorAsync(this.context.color).then(colors => {
+            this.context.hue = colors.Hue;
+            // shouldn't need this
+            // this.service.updateCharacteristic(this.platform.Characteristic.Hue, colors.Hue);
+            // this.service.updateCharacteristic(this.platform.Characteristic.Saturation, colors.Sat);
+            callback(null, this.context.hue);
+        }).catch((err) => {
             this.log.error(`${this.accessory.displayName} getHue error: ${err}`)
-            callback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE, false);
-        }
-
+            callback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE, false); 
+        });
     };
+
     setHue(desiredHue: number, callback: CharacteristicSetCallback): void {
         this.desiredHue = desiredHue;
         this.hueCallback = callback;
@@ -55,25 +52,24 @@ export class ZDC_Light extends ZD_Light {
     };
     
     getSaturation(callback: CharacteristicGetCallback): void {
-        try {
-            this.controller.GetColorAsync(this.context.color).then(colors => {
-                this.context.saturation = colors.Sat;
-                // shouldn't need this
-                // this.service.updateCharacteristic(this.platform.Characteristic.Hue, colors.Hue);
-                // this.service.updateCharacteristic(this.platform.Characteristic.Saturation, colors.Sat);
-                callback(null, this.context.saturation);
-            })
-        }
-        catch (err) {
+        this.controller.GetColorAsync(this.context.color).then(colors => {
+            this.context.saturation = colors.Sat;
+            // shouldn't need this
+            // this.service.updateCharacteristic(this.platform.Characteristic.Hue, colors.Hue);
+            // this.service.updateCharacteristic(this.platform.Characteristic.Saturation, colors.Sat);
+            callback(null, this.context.saturation);
+        }).catch((err) => {
             this.log.error(`${this.accessory.displayName} getSaturation error: ${err}`)
-            callback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE, false);
-        }
+            callback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE, false);   
+        });
     };
+
     setSaturation(desiredSaturation: number, callback: CharacteristicSetCallback): void {
         this.desiredSaturation = desiredSaturation;
         this.satCallback = callback;
         if (typeof this.hueCallback !== 'undefined') setTimeout(() => { this.colorListSetCallbacks() }, 200);
     };
+
     async colorListSet(): Promise<IStatus> {
         try {
             let status = await this.controller.ColorListSetAsync(this.context.color, this.desiredHue, this.desiredSaturation);
@@ -89,23 +85,22 @@ export class ZDC_Light extends ZD_Light {
             this.log.error(`${this.accessory.displayName} colorListSet error: ${err}`)
         };
     }
+
     colorListSetCallbacks(): void {
-        try {
-            this.colorListSet().then(() => {
-                if (typeof this.satCallback === 'function') this.satCallback(null);
-                this.satCallback = undefined;
-                if (typeof this.hueCallback === 'function') this.hueCallback(null);
-                this.hueCallback = undefined;
-            });
-        }
-        catch (err) {
+        this.colorListSet().then(() => {
+            if (typeof this.satCallback === 'function') this.satCallback(null);
+            this.satCallback = undefined;
+            if (typeof this.hueCallback === 'function') this.hueCallback(null);
+            this.hueCallback = undefined;
+        }).catch((err) => {
             this.log.error(`${this.accessory.displayName} colorListSetCallbacks error: ${err}`)
             if (typeof this.satCallback === 'function') this.satCallback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE);
             this.satCallback = undefined;
             if (typeof this.hueCallback === 'function') this.hueCallback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE);
-            this.hueCallback = undefined;
-        }
+            this.hueCallback = undefined; 
+        });
     }
+
     async groupListEditAsync(currentColor: number): Promise<void> {
         try {
             if (this.context.color === 0) return;
@@ -150,12 +145,14 @@ export class ZDC_Light extends ZD_Light {
             }
         })
     }
+
     setCharacteristics(): void {
         this.service.updateCharacteristic(this.platform.Characteristic.On, typeof this.context.isOn !== 'undefined' ? this.context.isOn : false);
         this.service.updateCharacteristic(this.platform.Characteristic.Brightness, typeof this.context.brightness !== 'undefined' ? this.context.brightness : 0);
         this.service.updateCharacteristic(this.platform.Characteristic.Hue, typeof this.context.hue !== 'undefined' ? this.context.hue : 0);
         this.service.updateCharacteristic(this.platform.Characteristic.Saturation, typeof this.context.saturation !== 'undefined' ? this.context.saturation : 0);
     }
+
     // this method used for callbacks
     callbackHue(hue: number): void {
         if (hue !== this.context.hue && this.context.color !== 0) {
@@ -164,6 +161,7 @@ export class ZDC_Light extends ZD_Light {
             this.service.updateCharacteristic(this.platform.Characteristic.Hue, hue);
         }
     };
+    
     callbackSat(saturation: number): void {
         if (saturation !== this.context.saturation && this.context.color !== 0) {
             this.context.saturation = saturation;

--- a/src/lights/ZD_Light.ts
+++ b/src/lights/ZD_Light.ts
@@ -41,14 +41,11 @@ export class ZD_Light {
             .on('get', this.getBrightness.bind(this));
             
             this.context.status = 'current';
-            try {
-                this.getCurrentStateAsync().then(() => {
-                    this.setCharacteristics();
-                });
-            }
-            catch(err){
-                this.log.error(`${this.accessory.displayName} setServices error: ${err}`)
-            }
+            this.getCurrentStateAsync().then(() => {
+                this.setCharacteristics();
+            }).catch((err) => {    
+                this.log.error(`${this.accessory.displayName} setServices error: ${err}`)        
+            });
         }
         catch (err){
             this.log.error(`setServices ${err}`)
@@ -71,55 +68,48 @@ export class ZD_Light {
         return new Promise(resolve => setTimeout(resolve, ms));
     }
     getOn(callback: CharacteristicGetCallback): void {
-        try {
-            // this.log.debug("Getting power state for: ", this.accessory.displayName);
-            this.getCurrentStateAsync().then(() => {
-                callback(null, this.context.isOn);
-            });
-        }
-        catch (err) {
+        this.log.debug("Getting power state for: ", this.accessory.displayName);
+
+        this.getCurrentStateAsync().then(() => {
+            callback(null, this.context.isOn);
+        }).catch((err) => {   
             this.log.error(`${this.accessory.displayName} error: ${err}`)
             this.context.isOn = false;
             callback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE, false);
-        }
+        });
     }
     setOn(desiredState: boolean, callback: CharacteristicSetCallback): void {
-        try {
-            if (this.context.isOn === desiredState) {
-                this.log.debug('Not changing power to %s because it is already %s', desiredState ? 'On' : 'Off', this.context.isOn ? 'On' : 'Off');
+        if (this.context.isOn === desiredState) {
+            this.log.debug('Not changing power to %s because it is already %s', desiredState ? 'On' : 'Off', this.context.isOn ? 'On' : 'Off');
+            callback(null);
+        } else {
+            this.illuminateGroupAsync(desiredState ? this.context.brightness || 100 : 0).then(() => {
                 callback(null);
-            } else {
-                this.illuminateGroupAsync(desiredState ? this.context.brightness || 100 : 0).then(() => callback(null));
-            }
-        }
-        catch (err) {
-            this.log.error(`${this.accessory.displayName} setOn error: ${err}`)
-            callback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE);
+            }).catch((err) => {  
+                this.log.error(`${this.accessory.displayName} setOn error: ${err}`)
+                callback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE);
+            });
         }
     }
     getBrightness(callback: CharacteristicGetCallback): void {
-        try {
-            this.getCurrentStateAsync().then(() => { callback(null, this.context.brightness); });
-        }
-        catch (err) {
+        this.getCurrentStateAsync().then(() => {
+            callback(null, this.context.brightness);
+        }).catch((err) => {  
             this.log.error(`${this.accessory.displayName} getBrightness error: ${err}`)
             callback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE, false);
-        }
+        });
     }
     setBrightness(desiredBrightness: number, callback: CharacteristicSetCallback): void {
-        try {
-            if (this.context.brightness === desiredBrightness) {
-                this.log.debug('Not changing brightness to %s because it is already %s', desiredBrightness, this.context.brightness);
+        if (this.context.brightness === desiredBrightness) {
+            this.log.debug('Not changing brightness to %s because it is already %s', desiredBrightness, this.context.brightness);
+            callback(null);
+        } else {
+            this.illuminateGroupAsync(desiredBrightness).then(() => {
                 callback(null);
-            } else {
-                this.illuminateGroupAsync(desiredBrightness).then(() => {
-                    callback(null);
-                });
-            }
-        }
-        catch (err) {
-            this.log.error(`${this.accessory.displayName} setBrightness error: ${err}`)
-            callback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE, false);
+            }).catch((err) => {  
+                this.log.error(`${this.accessory.displayName} setBrightness error: ${err}`)
+                callback(HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE, false);
+            });
         }
     }
 


### PR DESCRIPTION
This addresses several crashes that bring down Homebridge due to uncaught exceptions. Exceptions only propagate out of promises when awaiting them in an aysnc function. For synchronous functions `.catch()` should be used instead. 

This also addresses an issue with the initial controller creation: the plugin always waits 60 seconds to enumerate the devices even on a successful connection, and there is no timeout on the controller creation API calls. Not sure what controls the default timeout, but I was seeing this take up to two hours to timeout. 